### PR TITLE
[FEAT] 티켓 조회 API 구현

### DIFF
--- a/src/main/java/com/prgrms/be/intermark/common/dto/page/dto/PageListIndexSize.java
+++ b/src/main/java/com/prgrms/be/intermark/common/dto/page/dto/PageListIndexSize.java
@@ -2,7 +2,7 @@ package com.prgrms.be.intermark.common.dto.page.dto;
 
 public enum PageListIndexSize {
     MUSICAL_LIST_INDEX_SIZE(10),
-    SCHEDULE_LIST_INDEX_SIZE(10);
+    TICKET_LIST_INDEX_SIZE(10);
 
     private final int size;
 

--- a/src/main/java/com/prgrms/be/intermark/common/dto/page/dto/PageListIndexSize.java
+++ b/src/main/java/com/prgrms/be/intermark/common/dto/page/dto/PageListIndexSize.java
@@ -1,7 +1,8 @@
 package com.prgrms.be.intermark.common.dto.page.dto;
 
 public enum PageListIndexSize {
-    MUSICAL_LIST_INDEX_SIZE(10);
+    MUSICAL_LIST_INDEX_SIZE(10),
+    SCHEDULE_LIST_INDEX_SIZE(10);
 
     private final int size;
 

--- a/src/main/java/com/prgrms/be/intermark/common/service/page/PageService.java
+++ b/src/main/java/com/prgrms/be/intermark/common/service/page/PageService.java
@@ -1,0 +1,18 @@
+package com.prgrms.be.intermark.common.service.page;
+
+import com.prgrms.be.intermark.domain.ticket.model.Ticket;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PageService {
+
+    public PageRequest getPageRequest(Pageable pageable, int totalDataNumber) {
+        int pageNumber = Math.min(pageable.getPageNumber(), totalDataNumber / pageable.getPageSize() - 1);
+        return PageRequest.of(pageNumber, pageable.getPageSize());
+    }
+}

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/controller/TicketController.java
@@ -1,0 +1,26 @@
+package com.prgrms.be.intermark.domain.ticket.controller;
+
+import com.prgrms.be.intermark.common.dto.page.dto.PageResponseDTO;
+import com.prgrms.be.intermark.domain.ticket.dto.TicketResponseDTO;
+import com.prgrms.be.intermark.domain.ticket.model.Ticket;
+import com.prgrms.be.intermark.domain.ticket.service.TicketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tickets")
+public class TicketController {
+
+    private final TicketService ticketService;
+
+    @GetMapping
+    public ResponseEntity<PageResponseDTO<Ticket, TicketResponseDTO>> getAllTickets(Pageable pageable) {
+        PageResponseDTO<Ticket, TicketResponseDTO> tickets = ticketService.getAllTickets(pageable);
+        return ResponseEntity.ok(tickets);
+    }
+}

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/controller/TicketController.java
@@ -1,6 +1,7 @@
 package com.prgrms.be.intermark.domain.ticket.controller;
 
 import com.prgrms.be.intermark.common.dto.page.dto.PageResponseDTO;
+import com.prgrms.be.intermark.domain.ticket.dto.TicketResponseByMusicalDTO;
 import com.prgrms.be.intermark.domain.ticket.dto.TicketResponseByUserDTO;
 import com.prgrms.be.intermark.domain.ticket.dto.TicketResponseDTO;
 import com.prgrms.be.intermark.domain.ticket.model.Ticket;
@@ -30,6 +31,14 @@ public class TicketController {
     public ResponseEntity<PageResponseDTO<Ticket, TicketResponseByUserDTO>> getTicketsByUser(
             @PathVariable("userId") Long userId, Pageable pageable) {
         PageResponseDTO<Ticket, TicketResponseByUserDTO> tickets = ticketService.getTicketsByUser(userId, pageable);
+        return ResponseEntity.ok(tickets);
+    }
+
+    @GetMapping("/musicals/{musicalId}")
+    public ResponseEntity<PageResponseDTO<Ticket, TicketResponseByMusicalDTO>> getTicketsByMusical(
+            @PathVariable("musicalId") Long musicalId, Pageable pageable) {
+        PageResponseDTO<Ticket, TicketResponseByMusicalDTO> tickets = ticketService.getTicketsByMusical(
+                musicalId, pageable);
         return ResponseEntity.ok(tickets);
     }
 }

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/controller/TicketController.java
@@ -1,6 +1,7 @@
 package com.prgrms.be.intermark.domain.ticket.controller;
 
 import com.prgrms.be.intermark.common.dto.page.dto.PageResponseDTO;
+import com.prgrms.be.intermark.domain.ticket.dto.TicketResponseByUserDTO;
 import com.prgrms.be.intermark.domain.ticket.dto.TicketResponseDTO;
 import com.prgrms.be.intermark.domain.ticket.model.Ticket;
 import com.prgrms.be.intermark.domain.ticket.service.TicketService;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,6 +23,13 @@ public class TicketController {
     @GetMapping
     public ResponseEntity<PageResponseDTO<Ticket, TicketResponseDTO>> getAllTickets(Pageable pageable) {
         PageResponseDTO<Ticket, TicketResponseDTO> tickets = ticketService.getAllTickets(pageable);
+        return ResponseEntity.ok(tickets);
+    }
+
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<PageResponseDTO<Ticket, TicketResponseByUserDTO>> getTicketsByUser(
+            @PathVariable("userId") Long userId, Pageable pageable) {
+        PageResponseDTO<Ticket, TicketResponseByUserDTO> tickets = ticketService.getTicketsByUser(userId, pageable);
         return ResponseEntity.ok(tickets);
     }
 }

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/controller/TicketController.java
@@ -52,6 +52,7 @@ public class TicketController {
     public ResponseEntity<TicketResponseDTO> getTicketById(@PathVariable("ticketId") Long ticketId) {
         TicketResponseDTO ticket = ticketService.getTicketById(ticketId);
         return ResponseEntity.ok(ticket);
+    }
 
     @PostMapping
     public ResponseEntity<Void> createTicket(@RequestBody @Valid TicketCreateRequestDTO ticketCreateRequestDTO) {

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/controller/TicketController.java
@@ -41,4 +41,10 @@ public class TicketController {
                 musicalId, pageable);
         return ResponseEntity.ok(tickets);
     }
+
+    @GetMapping("/{ticketId}")
+    public ResponseEntity<TicketResponseDTO> getTicketById(@PathVariable("ticketId") Long ticketId) {
+        TicketResponseDTO ticket = ticketService.getTicketById(ticketId);
+        return ResponseEntity.ok(ticket);
+    }
 }

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseByMusicalDTO.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseByMusicalDTO.java
@@ -1,0 +1,46 @@
+package com.prgrms.be.intermark.domain.ticket.dto;
+
+import com.prgrms.be.intermark.domain.schedule.model.Schedule;
+import com.prgrms.be.intermark.domain.seat.model.Seat;
+import com.prgrms.be.intermark.domain.seatgrade.model.SeatGrade;
+import com.prgrms.be.intermark.domain.stadium.model.Stadium;
+import com.prgrms.be.intermark.domain.ticket.model.Ticket;
+import com.prgrms.be.intermark.domain.ticket.model.TicketStatus;
+import com.prgrms.be.intermark.domain.user.User;
+import lombok.Builder;
+
+import javax.validation.constraints.NotNull;
+import java.time.format.DateTimeFormatter;
+
+@Builder
+public record TicketResponseByMusicalDTO(
+        @NotNull Long ticketId,
+        @NotNull String nickname,
+        @NotNull TicketResponseSeatDTO seat,
+        @NotNull TicketResponseStadiumDTO stadium,
+        @NotNull TicketStatus ticketStatus
+) {
+
+    public static TicketResponseByMusicalDTO from(Ticket ticket) {
+        Schedule schedule = ticket.getSchedule();
+        Seat seat = ticket.getSeat();
+        SeatGrade seatGrade = ticket.getSeatGrade();
+        Stadium stadium = ticket.getStadium();
+        User user = ticket.getUser();
+
+        return TicketResponseByMusicalDTO.builder()
+                .ticketId(ticket.getId())
+                .nickname(user.getNickname())
+                .seat(TicketResponseSeatDTO.builder()
+                        .grade(seatGrade.getName())
+                        .seatNum(seat.getRowNum() + seat.getColumnNum())
+                        .build())
+                .stadium(TicketResponseStadiumDTO.builder()
+                        .name(stadium.getName())
+                        .address(stadium.getAddress())
+                        .build())
+                .ticketStatus(ticket.getTicketStatus())
+                .build();
+    }
+}
+

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseByUserDTO.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseByUserDTO.java
@@ -1,0 +1,50 @@
+package com.prgrms.be.intermark.domain.ticket.dto;
+
+import com.prgrms.be.intermark.domain.musical.model.Musical;
+import com.prgrms.be.intermark.domain.schedule.model.Schedule;
+import com.prgrms.be.intermark.domain.seat.model.Seat;
+import com.prgrms.be.intermark.domain.seatgrade.model.SeatGrade;
+import com.prgrms.be.intermark.domain.stadium.model.Stadium;
+import com.prgrms.be.intermark.domain.ticket.model.Ticket;
+import com.prgrms.be.intermark.domain.ticket.model.TicketStatus;
+import lombok.Builder;
+
+import javax.validation.constraints.NotNull;
+import java.time.format.DateTimeFormatter;
+
+@Builder
+public record TicketResponseByUserDTO(
+        @NotNull Long ticketId,
+        @NotNull TicketResponseMusicalDTO musical,
+        @NotNull TicketResponseSeatDTO seat,
+        @NotNull TicketResponseStadiumDTO stadium,
+        @NotNull TicketStatus ticketStatus
+) {
+
+    public static TicketResponseByUserDTO from(Ticket ticket) {
+        Musical musical = ticket.getMusical();
+        Schedule schedule = ticket.getSchedule();
+        Seat seat = ticket.getSeat();
+        SeatGrade seatGrade = ticket.getSeatGrade();
+        Stadium stadium = ticket.getStadium();
+
+        return TicketResponseByUserDTO.builder()
+                .ticketId(ticket.getId())
+                .musical(TicketResponseMusicalDTO.builder()
+                        .title(musical.getTitle())
+                        .startTime(schedule.getStartTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                        .runningTime(musical.getRunningTime())
+                        .rating(musical.getViewRating())
+                        .build())
+                .seat(TicketResponseSeatDTO.builder()
+                        .grade(seatGrade.getName())
+                        .seatNum(seat.getRowNum() + seat.getColumnNum())
+                        .build())
+                .stadium(TicketResponseStadiumDTO.builder()
+                        .name(stadium.getName())
+                        .address(stadium.getAddress())
+                        .build())
+                .ticketStatus(ticket.getTicketStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseDTO.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseDTO.java
@@ -1,0 +1,50 @@
+package com.prgrms.be.intermark.domain.ticket.dto;
+
+import com.prgrms.be.intermark.domain.musical.model.Musical;
+import com.prgrms.be.intermark.domain.schedule.model.Schedule;
+import com.prgrms.be.intermark.domain.seat.model.Seat;
+import com.prgrms.be.intermark.domain.seatgrade.model.SeatGrade;
+import com.prgrms.be.intermark.domain.stadium.model.Stadium;
+import com.prgrms.be.intermark.domain.ticket.model.Ticket;
+import com.prgrms.be.intermark.domain.ticket.model.TicketStatus;
+import lombok.Builder;
+
+import javax.validation.constraints.NotNull;
+import java.time.format.DateTimeFormatter;
+
+@Builder
+public record TicketResponseDTO(
+        @NotNull Long ticketId,
+        @NotNull TicketResponseMusicalDTO musical,
+        @NotNull TicketResponseSeatDTO seat,
+        @NotNull TicketResponseStadiumDTO stadium,
+        @NotNull TicketStatus ticketStatus
+) {
+
+    public static TicketResponseDTO from(Ticket ticket) {
+        Musical musical = ticket.getMusical();
+        Schedule schedule = ticket.getSchedule();
+        Seat seat = ticket.getSeat();
+        SeatGrade seatGrade = ticket.getSeatGrade();
+        Stadium stadium = ticket.getStadium();
+
+        return TicketResponseDTO.builder()
+                .ticketId(ticket.getId())
+                .musical(TicketResponseMusicalDTO.builder()
+                        .title(musical.getTitle())
+                        .startTime(schedule.getStartTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                        .runningTime(musical.getRunningTime())
+                        .rating(musical.getViewRating())
+                        .build())
+                .seat(TicketResponseSeatDTO.builder()
+                        .grade(seatGrade.getName())
+                        .seatNum(seat.getRowNum() + seat.getColumnNum())
+                        .build())
+                .stadium(TicketResponseStadiumDTO.builder()
+                        .name(stadium.getName())
+                        .address(stadium.getAddress())
+                        .build())
+                .ticketStatus(ticket.getTicketStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseDTO.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseDTO.java
@@ -7,6 +7,7 @@ import com.prgrms.be.intermark.domain.seatgrade.model.SeatGrade;
 import com.prgrms.be.intermark.domain.stadium.model.Stadium;
 import com.prgrms.be.intermark.domain.ticket.model.Ticket;
 import com.prgrms.be.intermark.domain.ticket.model.TicketStatus;
+import com.prgrms.be.intermark.domain.user.User;
 import lombok.Builder;
 
 import javax.validation.constraints.NotNull;
@@ -15,6 +16,7 @@ import java.time.format.DateTimeFormatter;
 @Builder
 public record TicketResponseDTO(
         @NotNull Long ticketId,
+        @NotNull String nickname,
         @NotNull TicketResponseMusicalDTO musical,
         @NotNull TicketResponseSeatDTO seat,
         @NotNull TicketResponseStadiumDTO stadium,
@@ -27,9 +29,11 @@ public record TicketResponseDTO(
         Seat seat = ticket.getSeat();
         SeatGrade seatGrade = ticket.getSeatGrade();
         Stadium stadium = ticket.getStadium();
+        User user = ticket.getUser();
 
         return TicketResponseDTO.builder()
                 .ticketId(ticket.getId())
+                .nickname(user.getNickname())
                 .musical(TicketResponseMusicalDTO.builder()
                         .title(musical.getTitle())
                         .startTime(schedule.getStartTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseMusicalDTO.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseMusicalDTO.java
@@ -1,0 +1,15 @@
+package com.prgrms.be.intermark.domain.ticket.dto;
+
+import com.prgrms.be.intermark.domain.musical.model.ViewRating;
+import lombok.Builder;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.constraints.NotNull;
+
+@Builder
+public record TicketResponseMusicalDTO(
+        @NotNull String title,
+        @NotNull @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm") String startTime,
+        @NotNull int runningTime,
+        @NotNull ViewRating rating) {
+}

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseSeatDTO.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseSeatDTO.java
@@ -1,0 +1,11 @@
+package com.prgrms.be.intermark.domain.ticket.dto;
+
+import lombok.Builder;
+
+import javax.validation.constraints.NotNull;
+
+@Builder
+public record TicketResponseSeatDTO(
+        @NotNull String grade,
+        @NotNull String seatNum) {
+}

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseStadiumDTO.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/dto/TicketResponseStadiumDTO.java
@@ -1,0 +1,11 @@
+package com.prgrms.be.intermark.domain.ticket.dto;
+
+import lombok.Builder;
+
+import javax.validation.constraints.NotNull;
+
+@Builder
+public record TicketResponseStadiumDTO(
+        @NotNull String name,
+        @NotNull String address) {
+}

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/repository/TicketRepository.java
@@ -1,7 +1,13 @@
 package com.prgrms.be.intermark.domain.ticket.repository;
 
 import com.prgrms.be.intermark.domain.ticket.model.Ticket;
+import com.prgrms.be.intermark.domain.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
+    Page<Ticket> findByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/repository/TicketRepository.java
@@ -6,9 +6,6 @@ import com.prgrms.be.intermark.domain.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
     Page<Ticket> findByUser(User user, Pageable pageable);

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/repository/TicketRepository.java
@@ -1,5 +1,6 @@
 package com.prgrms.be.intermark.domain.ticket.repository;
 
+import com.prgrms.be.intermark.domain.musical.model.Musical;
 import com.prgrms.be.intermark.domain.ticket.model.Ticket;
 import com.prgrms.be.intermark.domain.user.User;
 import org.springframework.data.domain.Page;
@@ -10,4 +11,6 @@ import java.util.List;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
     Page<Ticket> findByUser(User user, Pageable pageable);
+
+    Page<Ticket> findByMusical(Musical musical, Pageable pageable);
 }

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/repository/TicketRepository.java
@@ -1,0 +1,7 @@
+package com.prgrms.be.intermark.domain.ticket.repository;
+
+import com.prgrms.be.intermark.domain.ticket.model.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+}

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/repository/TicketRepository.java
@@ -6,6 +6,7 @@ import com.prgrms.be.intermark.domain.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -13,4 +14,8 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
     Page<Ticket> findByUser(User user, Pageable pageable);
 
     Page<Ticket> findByMusical(Musical musical, Pageable pageable);
+
+    long countByUser(User user);
+
+    long countByMusical(Musical musical);
 }

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
@@ -58,6 +58,12 @@ public class TicketService {
         Page<Ticket> ticketPage = ticketRepository.findByMusical(musical, pageable);
         return new PageResponseDTO<>(
                 ticketPage, TicketResponseByMusicalDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);
+    }
 
+    @Transactional(readOnly = true)
+    public TicketResponseDTO getTicketById(Long ticketId) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 티켓이 존재하지 않습니다."));
+        return TicketResponseDTO.from(ticket);
     }
 }

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
@@ -11,6 +11,7 @@ import com.prgrms.be.intermark.domain.user.User;
 import com.prgrms.be.intermark.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,7 +56,12 @@ public class TicketService {
             throw new EntityNotFoundException("해당 뮤지컬이 존재하지 않습니다.");
         }
 
-        Page<Ticket> ticketPage = ticketRepository.findByMusical(musical, pageable);
+        int maxPageNumber = (int) ticketRepository.count() / pageable.getPageSize() - 1;
+        int pageNumber = Math.min(pageable.getPageNumber(), maxPageNumber);
+
+        Page<Ticket> ticketPage = ticketRepository.findByMusical(
+                musical, PageRequest.of(pageNumber, pageable.getPageSize()));
+
         return new PageResponseDTO<>(
                 ticketPage, TicketResponseByMusicalDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);
     }

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
@@ -28,7 +28,9 @@ public class TicketService {
 
     @Transactional(readOnly = true)
     public PageResponseDTO<Ticket, TicketResponseDTO> getAllTickets(Pageable pageable) {
-        Page<Ticket> ticketPage = ticketRepository.findAll(pageable);
+        int maxPageNumber = (int) ticketRepository.count() / pageable.getPageSize() - 1;
+        int pageNumber = Math.min(pageable.getPageNumber(), maxPageNumber);
+        Page<Ticket> ticketPage = ticketRepository.findAll(PageRequest.of(pageNumber, pageable.getPageSize()));
         return new PageResponseDTO<>(ticketPage, TicketResponseDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);
     }
 
@@ -56,11 +58,7 @@ public class TicketService {
             throw new EntityNotFoundException("해당 뮤지컬이 존재하지 않습니다.");
         }
 
-        int maxPageNumber = (int) ticketRepository.count() / pageable.getPageSize() - 1;
-        int pageNumber = Math.min(pageable.getPageNumber(), maxPageNumber);
-
-        Page<Ticket> ticketPage = ticketRepository.findByMusical(
-                musical, PageRequest.of(pageNumber, pageable.getPageSize()));
+        Page<Ticket> ticketPage = ticketRepository.findByMusical(musical, pageable);
 
         return new PageResponseDTO<>(
                 ticketPage, TicketResponseByMusicalDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
@@ -10,12 +10,15 @@ import com.prgrms.be.intermark.domain.stadium.model.Stadium;
 import com.prgrms.be.intermark.domain.ticket.dto.*;
 import com.prgrms.be.intermark.domain.ticket.model.Ticket;
 import com.prgrms.be.intermark.domain.ticket.repository.TicketRepository;
+import com.prgrms.be.intermark.domain.user.User;
+import com.prgrms.be.intermark.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,10 +28,26 @@ import java.util.List;
 public class TicketService {
 
     private final TicketRepository ticketRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public PageResponseDTO<Ticket, TicketResponseDTO> getAllTickets(Pageable pageable) {
         Page<Ticket> ticketPage = ticketRepository.findAll(pageable);
-        return new PageResponseDTO<>(ticketPage, TicketResponseDTO::from, PageListIndexSize.MUSICAL_LIST_INDEX_SIZE);
+        return new PageResponseDTO<>(ticketPage, TicketResponseDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDTO<Ticket, TicketResponseByUserDTO> getTicketsByUser(Long userId, Pageable pageable) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 유저가 존재하지 않습니다."));
+
+        if (user.isDeleted()) {
+            throw new EntityNotFoundException("해당 유저가 존재하지 않습니다.");
+        }
+
+        Page<Ticket> ticketPage = ticketRepository.findByUser(user, pageable);
+        return new PageResponseDTO<>(
+                ticketPage, TicketResponseByUserDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);
+
     }
 }

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
@@ -1,0 +1,34 @@
+package com.prgrms.be.intermark.domain.ticket.service;
+
+import com.prgrms.be.intermark.common.dto.page.dto.PageListIndexSize;
+import com.prgrms.be.intermark.common.dto.page.dto.PageResponseDTO;
+import com.prgrms.be.intermark.domain.musical.model.Musical;
+import com.prgrms.be.intermark.domain.schedule.model.Schedule;
+import com.prgrms.be.intermark.domain.seat.model.Seat;
+import com.prgrms.be.intermark.domain.seatgrade.model.SeatGrade;
+import com.prgrms.be.intermark.domain.stadium.model.Stadium;
+import com.prgrms.be.intermark.domain.ticket.dto.*;
+import com.prgrms.be.intermark.domain.ticket.model.Ticket;
+import com.prgrms.be.intermark.domain.ticket.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+
+    @Transactional(readOnly = true)
+    public PageResponseDTO<Ticket, TicketResponseDTO> getAllTickets(Pageable pageable) {
+        Page<Ticket> ticketPage = ticketRepository.findAll(pageable);
+        return new PageResponseDTO<>(ticketPage, TicketResponseDTO::from, PageListIndexSize.MUSICAL_LIST_INDEX_SIZE);
+    }
+}

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
@@ -2,6 +2,7 @@ package com.prgrms.be.intermark.domain.ticket.service;
 
 import com.prgrms.be.intermark.common.dto.page.dto.PageListIndexSize;
 import com.prgrms.be.intermark.common.dto.page.dto.PageResponseDTO;
+import com.prgrms.be.intermark.common.service.page.PageService;
 import com.prgrms.be.intermark.domain.musical.model.Musical;
 import com.prgrms.be.intermark.domain.musical.repository.MusicalRepository;
 import com.prgrms.be.intermark.domain.ticket.dto.*;
@@ -25,12 +26,13 @@ public class TicketService {
     private final TicketRepository ticketRepository;
     private final UserRepository userRepository;
     private final MusicalRepository musicalRepository;
+    private final PageService pageService;
 
     @Transactional(readOnly = true)
     public PageResponseDTO<Ticket, TicketResponseDTO> getAllTickets(Pageable pageable) {
-        int maxPageNumber = (int) ticketRepository.count() / pageable.getPageSize() - 1;
-        int pageNumber = Math.min(pageable.getPageNumber(), maxPageNumber);
-        Page<Ticket> ticketPage = ticketRepository.findAll(PageRequest.of(pageNumber, pageable.getPageSize()));
+        PageRequest pageRequest = pageService.getPageRequest(pageable, (int) ticketRepository.count());
+        Page<Ticket> ticketPage = ticketRepository.findAll(pageRequest);
+
         return new PageResponseDTO<>(ticketPage, TicketResponseDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);
     }
 
@@ -43,10 +45,11 @@ public class TicketService {
             throw new EntityNotFoundException("해당 유저가 존재하지 않습니다.");
         }
 
-        Page<Ticket> ticketPage = ticketRepository.findByUser(user, pageable);
+        PageRequest pageRequest = pageService.getPageRequest(pageable, (int) ticketRepository.countByUser(user));
+        Page<Ticket> ticketPage = ticketRepository.findByUser(user, pageRequest);
+
         return new PageResponseDTO<>(
                 ticketPage, TicketResponseByUserDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);
-
     }
 
     @Transactional(readOnly = true)
@@ -58,7 +61,8 @@ public class TicketService {
             throw new EntityNotFoundException("해당 뮤지컬이 존재하지 않습니다.");
         }
 
-        Page<Ticket> ticketPage = ticketRepository.findByMusical(musical, pageable);
+        PageRequest pageRequest = pageService.getPageRequest(pageable, (int) ticketRepository.countByMusical(musical));
+        Page<Ticket> ticketPage = ticketRepository.findByMusical(musical, pageRequest);
 
         return new PageResponseDTO<>(
                 ticketPage, TicketResponseByMusicalDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
@@ -3,10 +3,7 @@ package com.prgrms.be.intermark.domain.ticket.service;
 import com.prgrms.be.intermark.common.dto.page.dto.PageListIndexSize;
 import com.prgrms.be.intermark.common.dto.page.dto.PageResponseDTO;
 import com.prgrms.be.intermark.domain.musical.model.Musical;
-import com.prgrms.be.intermark.domain.schedule.model.Schedule;
-import com.prgrms.be.intermark.domain.seat.model.Seat;
-import com.prgrms.be.intermark.domain.seatgrade.model.SeatGrade;
-import com.prgrms.be.intermark.domain.stadium.model.Stadium;
+import com.prgrms.be.intermark.domain.musical.repository.MusicalRepository;
 import com.prgrms.be.intermark.domain.ticket.dto.*;
 import com.prgrms.be.intermark.domain.ticket.model.Ticket;
 import com.prgrms.be.intermark.domain.ticket.repository.TicketRepository;
@@ -19,9 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -29,6 +23,7 @@ public class TicketService {
 
     private final TicketRepository ticketRepository;
     private final UserRepository userRepository;
+    private final MusicalRepository musicalRepository;
 
     @Transactional(readOnly = true)
     public PageResponseDTO<Ticket, TicketResponseDTO> getAllTickets(Pageable pageable) {
@@ -48,6 +43,21 @@ public class TicketService {
         Page<Ticket> ticketPage = ticketRepository.findByUser(user, pageable);
         return new PageResponseDTO<>(
                 ticketPage, TicketResponseByUserDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);
+
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDTO<Ticket, TicketResponseByMusicalDTO> getTicketsByMusical(Long musicalId, Pageable pageable) {
+        Musical musical = musicalRepository.findById(musicalId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 뮤지컬이 존재하지 않습니다."));
+
+        if (musical.isDeleted()) {
+            throw new EntityNotFoundException("해당 뮤지컬이 존재하지 않습니다.");
+        }
+
+        Page<Ticket> ticketPage = ticketRepository.findByMusical(musical, pageable);
+        return new PageResponseDTO<>(
+                ticketPage, TicketResponseByMusicalDTO::from, PageListIndexSize.TICKET_LIST_INDEX_SIZE);
 
     }
 }

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/service/TicketService.java
@@ -78,6 +78,7 @@ public class TicketService {
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 티켓이 존재하지 않습니다."));
         return TicketResponseDTO.from(ticket);
+    }
 
     @Transactional
     public Long createTicket(TicketCreateRequestDTO ticketCreateRequestDTO) {


### PR DESCRIPTION
<!-- 이슈와 PR 이름을 맞춰주세요!! -->
<!-- 여러 라인에 걸쳐 문장이 필요한 경우, 각 라인마다 "-" 를 이용해주세요 -->

## PR Description 🗒️
<!-- 
PR에 대한 간략한 설명을 적어주세요
ex)
- 로그인 기능 추가.
-->
티켓 조회 기능을 구현하였습니다. 거의 모든 파일이 겹치는 이유로, API 4개를 한 브랜치에서 구현하여 PR을 보냅니다..!
- 티켓 전체 조회 API
- 티켓 유저별 조회 API
- 티켓 뮤지컬별 조회 API
- 티켓 상세 조회 API

## 추가 사항 및 설명 ➕
<!-- 
[FEAT] / [ADD]
추가 사항과 이에 대한 설명을 적어주세요
ex)
- 예매 기능 추가
    - 
-->
- 티켓 상세 조회에서, ticket 엔티티에 isDeleted 필드가 존재하지 않아서, 관련 필드 참거짓 여부는 제외하고 티켓 존재 관련 예외처리 했습니다.

## 수정 사항 및 이유 🔄
<!-- 
[CHORE] / [FIX] / [HOTFIX] / [REFACTOR]
수정 사항과 수정한 이유를 작성해주세요.
ex)
- 파라미터 타입을 Long에서 long으로 수정.
    - null이 포함되지 않고 단순 연산만 수행하여 수정.
-->

## To Reviewers 🙏
<!-- 
리뷰어들이 중점적으로 봐줬으면 하는 부분이나 
리뷰어들에게 추가적으로 하고 싶은 말을 적어주세요!! 
-->



closed #96 