### PR TITLE
[FIX] : 유니크 제약조건 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // Rest Docs
+    asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
 }
 
 test {

--- a/src/main/java/com/prgrms/be/intermark/domain/schedule/model/Schedule.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/schedule/model/Schedule.java
@@ -1,37 +1,23 @@
 package com.prgrms.be.intermark.domain.schedule.model;
 
+import com.prgrms.be.intermark.domain.musical.model.Musical;
+import com.prgrms.be.intermark.domain.schedule_seat.model.ScheduleSeat;
+import com.prgrms.be.intermark.domain.ticket.model.Ticket;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
-import javax.validation.constraints.NotNull;
-
-import org.springframework.util.Assert;
-
-import com.prgrms.be.intermark.domain.musical.model.Musical;
-import com.prgrms.be.intermark.domain.schedule_seat.model.ScheduleSeat;
-import com.prgrms.be.intermark.domain.ticket.model.Ticket;
-
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 @Entity
-@Table(name = "schedule",
-        uniqueConstraints = {@UniqueConstraint(name = "musical_start_time_uk", columnNames = {"musical_id", "start_time"})})
+@Table(name = "schedule")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Schedule {

--- a/src/main/java/com/prgrms/be/intermark/domain/ticket/model/Ticket.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/ticket/model/Ticket.java
@@ -1,37 +1,23 @@
 package com.prgrms.be.intermark.domain.ticket.model;
 
-import java.util.Objects;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
-import javax.validation.constraints.NotNull;
-
-import org.springframework.util.Assert;
-
 import com.prgrms.be.intermark.domain.musical.model.Musical;
 import com.prgrms.be.intermark.domain.schedule.model.Schedule;
 import com.prgrms.be.intermark.domain.seat.model.Seat;
 import com.prgrms.be.intermark.domain.seatgrade.model.SeatGrade;
 import com.prgrms.be.intermark.domain.stadium.model.Stadium;
 import com.prgrms.be.intermark.domain.user.User;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
 
 @Entity
-@Table(name = "ticket", uniqueConstraints = {@UniqueConstraint(name = "ticket_uk", columnNames = {"schedule_id", "seat_id"})})
+@Table(name = "ticket")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Ticket {


### PR DESCRIPTION
## PR Description 🗒️
closed #120 
- 일부 엔티티의 유니크 키 제약조건을 제거해주었다.

## 추가 사항 및 설명 ➕

## 수정 사항 및 이유 🔄
- Schedule 의 경우 기존에 musicalId 와 startTime 이 복합 유니크키로 지정되어 있었는데 isDeleted 가 True 인 경우에는 삭제된 스케줄이기 때문에 musicalId 와 startTime 이 중복인 데이터가 있을 수 있다.

## To Reviewers 🙏