### PR TITLE
[FIX] : 배포 서버에서 이미지 S3 업로드 안되는 오류 수정

### DIFF
--- a/src/main/java/com/prgrms/be/intermark/common/service/S3ImageUploadService.java
+++ b/src/main/java/com/prgrms/be/intermark/common/service/S3ImageUploadService.java
@@ -1,6 +1,7 @@
 package com.prgrms.be.intermark.common.service;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.prgrms.be.intermark.common.dto.ImageResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
@@ -25,18 +25,24 @@ public class S3ImageUploadService implements ImageUploadService {
 	@Value("${cloud.aws.s3.bucket.name}")
 	private String bucketName;
 
-	@Value("${local.images.path}")
-	private String localRootPath;
-
 	@Override
 	@Transactional
 	public ImageResponseDTO uploadImage(MultipartFile multipartFile, String subPath) {
-		File uploadImage = uploadOnLocal(multipartFile, subPath);
 
-		amazonS3.putObject(new PutObjectRequest(bucketName, subPath + uploadImage.getName(), uploadImage));
-		String savedFileS3Url = amazonS3.getUrl(bucketName, subPath + uploadImage.getName()).toString();
+		if (multipartFile.isEmpty()) {
+			throw new IllegalArgumentException("이미지가 없습니다.");
+		}
 
-		deleteLocalImage(uploadImage);
+		String originalFilename = multipartFile.getOriginalFilename();
+		String savedFileName = createSavedFileName(originalFilename);
+
+		try {
+			amazonS3.putObject(new PutObjectRequest(bucketName, subPath + savedFileName, multipartFile.getInputStream(), new ObjectMetadata()));
+		} catch (IOException e) {
+			throw new IllegalStateException("이미지를 업로드할 수 없습니다.");
+		}
+
+		String savedFileS3Url = amazonS3.getUrl(bucketName, subPath + savedFileName).toString();
 
 		return ImageResponseDTO.builder()
 			.originalFileName(multipartFile.getOriginalFilename())
@@ -52,25 +58,6 @@ public class S3ImageUploadService implements ImageUploadService {
 			.toList();
 	}
 
-	private File uploadOnLocal(MultipartFile multipartFile, String subPath) {
-		if (multipartFile.isEmpty()) {
-			throw new IllegalArgumentException("이미지가 없습니다.");
-		}
-
-		String originalFilename = multipartFile.getOriginalFilename();
-		String savedFileName = createSavedFileName(originalFilename);
-		String savedFileLocalPath = getSavedFileLocalPath(subPath, savedFileName);
-		File uploadImage = new File(savedFileLocalPath);
-
-		try {
-			multipartFile.transferTo(uploadImage);
-		} catch (IOException e) {
-			throw new IllegalArgumentException("이미지를 업로드할 수 없습니다.", e);
-		}
-
-		return uploadImage;
-	}
-
 	private String createSavedFileName(String originalFileName) {
 		String uuid = UUID.randomUUID().toString();
 		return uuid + "." + extractExtension(originalFileName);
@@ -79,13 +66,5 @@ public class S3ImageUploadService implements ImageUploadService {
 	private String extractExtension(String originalFileName) {
 		int beforeExtensionIndex = originalFileName.lastIndexOf(".");
 		return originalFileName.substring(beforeExtensionIndex + 1);
-	}
-
-	private String getSavedFileLocalPath(String subPath, String savedFileName) {
-		return localRootPath + subPath + savedFileName;
-	}
-
-	private void deleteLocalImage(File uploadImage) {
-		uploadImage.delete();
 	}
 }


### PR DESCRIPTION
## PR Description 🗒️
closed #147 

- 배포 서버에서 s3 로 이미지가 업로드 되지 않는 오류를 해결하기 위해 코드를 수정했습니다.

기존 로직: 서버 내부 폴더에 이미지 저장 -> s3 업로드 -> 서버 내부에 저장된 이미지 삭제
수정된 로직: 받은 스트림 파일을 바로 s3 업로드

## 추가 사항 및 설명 ➕

## 수정 사항 및 이유 🔄

## To Reviewers 🙏