### PR TITLE
[FEAT] 스케줄 삭제 중 예매가 존재하는 스케줄 삭제 불가 로직 기능 추가 및 테스트

### DIFF
--- a/src/main/java/com/prgrms/be/intermark/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/prgrms/be/intermark/domain/schedule/service/ScheduleService.java
@@ -15,6 +15,7 @@ import com.prgrms.be.intermark.domain.schedule_seat.dto.ScheduleSeatResponseDTO;
 import com.prgrms.be.intermark.domain.schedule_seat.dto.ScheduleSeatResponseDTOs;
 import com.prgrms.be.intermark.domain.schedule_seat.model.ScheduleSeat;
 import com.prgrms.be.intermark.domain.schedule_seat.repository.ScheduleSeatRepository;
+import com.prgrms.be.intermark.domain.ticket.model.Ticket;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -91,6 +92,12 @@ public class ScheduleService {
 	public void deleteSchedule(Long scheduleId) {
 		Schedule schedule = scheduleRepository.findById(scheduleId)
 			.orElseThrow(() -> new EntityNotFoundException("해당 스케줄이 존재하지 않습니다."));
+
+		List<Ticket> tickets = schedule.getTickets().stream().filter((Ticket::isReserved)).toList();
+
+		if (tickets.size() > 0) {
+			throw new IllegalStateException("예매된 스케줄은 삭제할 수 없습니다.");
+		}
 
 		if (schedule.isDeleted()) {
 			throw new EntityNotFoundException("이미 삭제된 스케줄입니다.");

--- a/src/test/java/com/prgrms/be/intermark/domain/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/prgrms/be/intermark/domain/schedule/service/ScheduleServiceTest.java
@@ -58,6 +58,8 @@ class ScheduleServiceTest {
 
     @Mock
     private TicketRepository ticketRepository;
+
+    @Mock
     private ScheduleSeatRepository scheduleSeatRepository;
 
     private final Stadium stadium = Stadium.builder()

--- a/src/test/java/com/prgrms/be/intermark/domain/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/prgrms/be/intermark/domain/schedule/service/ScheduleServiceTest.java
@@ -9,7 +9,12 @@ import com.prgrms.be.intermark.domain.schedule.dto.ScheduleCreateRequestDTO;
 import com.prgrms.be.intermark.domain.schedule.dto.ScheduleUpdateRequestDTO;
 import com.prgrms.be.intermark.domain.schedule.model.Schedule;
 import com.prgrms.be.intermark.domain.schedule.repository.ScheduleRepository;
+import com.prgrms.be.intermark.domain.seat.model.Seat;
+import com.prgrms.be.intermark.domain.seatgrade.model.SeatGrade;
 import com.prgrms.be.intermark.domain.stadium.model.Stadium;
+import com.prgrms.be.intermark.domain.ticket.model.Ticket;
+import com.prgrms.be.intermark.domain.ticket.model.TicketStatus;
+import com.prgrms.be.intermark.domain.ticket.repository.TicketRepository;
 import com.prgrms.be.intermark.domain.user.SocialType;
 import com.prgrms.be.intermark.domain.user.User;
 import com.prgrms.be.intermark.domain.user.UserRole;
@@ -46,6 +51,9 @@ class ScheduleServiceTest {
 
     @Mock
     private MusicalSeatRepository musicalSeatRepository;
+
+    @Mock
+    private TicketRepository ticketRepository;
 
     private final Stadium stadium = Stadium.builder()
             .name("stadium")
@@ -263,6 +271,39 @@ class ScheduleServiceTest {
         // then
         verify(scheduleRepository).findById(schedule.getId());
         assertThat(schedule.isDeleted()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("Fail - 예매 내역이 있는 스케줄을 삭제하면 IllegalStateException 발생")
+    void deleteScheduleHasTicketFail() {
+        // given
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        Schedule schedule = Schedule.builder()
+                .startTime(LocalDateTime.parse("2022-12-31 11:00", formatter))
+                .endTime(LocalDateTime.parse("2022-12-31 12:20", formatter))
+                .musical(musical)
+                .build();
+
+        Ticket ticket = Ticket.builder()
+                .ticketStatus(TicketStatus.AVAILABLE)
+                .user(user)
+                .schedule(schedule)
+                .seat(Seat.builder().build())
+                .seatGrade(SeatGrade.builder().build())
+                .musical(musical)
+                .stadium(stadium)
+                .build();
+
+        ticket.setSchedule(schedule);
+
+        when(scheduleRepository.findById(schedule.getId())).thenReturn(Optional.of(schedule));
+
+        // when - then
+        assertThatThrownBy(() -> scheduleService.deleteSchedule(schedule.getId()))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("예매된 스케줄은 삭제할 수 없습니다.");
+
+        verify(scheduleRepository).findById(schedule.getId());
     }
 
     @Test


### PR DESCRIPTION
<!-- 이슈와 PR 이름을 맞춰주세요!! -->
<!-- 여러 라인에 걸쳐 문장이 필요한 경우, 각 라인마다 "-" 를 이용해주세요 -->

## PR Description 🗒️
<!-- 
PR에 대한 간략한 설명을 적어주세요
ex)
- 로그인 기능 추가.
-->
예매 되어있는 스케줄은 삭제가 불가한 예외 로직을 추가하였습니다. (테스트 완료)

## 추가 사항 및 설명 ➕
<!-- 
[FEAT] / [ADD]
추가 사항과 이에 대한 설명을 적어주세요
ex)
- 예매 기능 추가
    - 
-->

## 수정 사항 및 이유 🔄
<!-- 
[CHORE] / [FIX] / [HOTFIX] / [REFACTOR]
수정 사항과 수정한 이유를 작성해주세요.
ex)
- 파라미터 타입을 Long에서 long으로 수정.
    - null이 포함되지 않고 단순 연산만 수행하여 수정.
-->

## To Reviewers 🙏
<!-- 
리뷰어들이 중점적으로 봐줬으면 하는 부분이나 
리뷰어들에게 추가적으로 하고 싶은 말을 적어주세요!! 
-->

closed #161 